### PR TITLE
[MARLIN-438] supporting creditcard account_type

### DIFF
--- a/lib/ofx/parser/ofx102.rb
+++ b/lib/ofx/parser/ofx102.rb
@@ -7,7 +7,8 @@ module OFX
         "CHECKING" => :checking,
         "SAVINGS"  => :savings,
         "CREDITLINE" => :creditline,
-        "MONEYMRKT" => :moneymrkt
+        "MONEYMRKT" => :moneymrkt,
+        "CREDITCARD" => :creditcard
       }
 
       TRANSACTION_TYPES = [
@@ -86,12 +87,17 @@ module OFX
         OFX::Account.new({
           :bank_id           => node.search("bankacctfrom > bankid").inner_text,
           :id                => node.search("bankacctfrom > acctid, ccacctfrom > acctid").inner_text,
-          :type              => ACCOUNT_TYPES[node.search("bankacctfrom > accttype").inner_text.to_s.upcase],
+          :type              => fetch_account_type(node),
           :transactions      => build_transactions(node),
           :balance           => build_balance(node),
           :available_balance => build_available_balance(node),
           :currency          => node.search("stmtrs > curdef, ccstmtrs > curdef").inner_text
         })
+      end
+
+      def fetch_account_type(node)
+        acct_type = ACCOUNT_TYPES[node.search("bankacctfrom > accttype").inner_text.to_s.upcase]
+        acct_type ||= node.search('ccacctinfo').any? ? :creditcard : nil
       end
 
       def build_status(node)

--- a/lib/ofx/parser/ofx102.rb
+++ b/lib/ofx/parser/ofx102.rb
@@ -135,7 +135,8 @@ module OFX
           :ref_number        => element.search("refnum").inner_text,
           :posted_at         => build_date(element.search("dtposted").inner_text),
           :type              => build_type(element),
-          :sic               => element.search("sic").inner_text
+          :sic               => element.search("sic").inner_text,
+          :extdname          => element.search("extdname").inner_text
         })
       end
 

--- a/lib/ofx/parser/ofx220.rb
+++ b/lib/ofx/parser/ofx220.rb
@@ -16,8 +16,13 @@ module OFX
           description:       node.search('desc').inner_text.upcase,
           bank_id:           nested_account_info.search('bankid').inner_text,
           id:                nested_account_info.search('acctid').inner_text,
-          type:              ACCOUNT_TYPES[node.search('accttype').inner_text.to_s.upcase],
+          type:              fetch_account_type(node),
         })
+      end
+
+      def fetch_account_type(node)
+        acct_type = ACCOUNT_TYPES[node.search('accttype').inner_text.to_s.upcase]
+        acct_type ||= node.search('ccacctinfo').any? ? :creditcard : nil
       end
     end
   end

--- a/lib/ofx/transaction.rb
+++ b/lib/ofx/transaction.rb
@@ -11,5 +11,6 @@ module OFX
     attr_accessor :ref_number
     attr_accessor :type
     attr_accessor :sic
+    attr_accessor :extdname
   end
 end

--- a/spec/ofx/ofx220_spec.rb
+++ b/spec/ofx/ofx220_spec.rb
@@ -64,7 +64,7 @@ describe OFX::Parser::OFX220 do
         @acct_info.description.should == 'CREDIT CARD'
         @acct_info.bank_id.should == ''
         @acct_info.id.should == '4400720'
-        @acct_info.type.should == nil
+        @acct_info.type.should == :creditcard
       end
     end
 


### PR DESCRIPTION
Added logic to identify creditcard account and suitably populate acct_type field