### PR TITLE
[MARLINSUP-482] Supporting autopay flag in creditcard closing transaction

### DIFF
--- a/lib/ofx/liability_closing_info.rb
+++ b/lib/ofx/liability_closing_info.rb
@@ -15,5 +15,6 @@ module OFX
 
     attr_accessor :last_payment_date
     attr_accessor :last_payment_amount
+    attr_accessor :autopay
   end
 end

--- a/lib/ofx/parser/ofx102.rb
+++ b/lib/ofx/parser/ofx102.rb
@@ -228,6 +228,7 @@ module OFX
           past_due_amount: to_decimal_or_nil(nested_closing.search('pastdueamt').inner_text),
           last_payment_date: build_date_or_nil(nested_closing.search('lastpmtinfo > lastpmtdate').inner_text),
           last_payment_amount: to_decimal_or_nil(nested_closing.search('lastpmtinfo > lastpmtamt').inner_text),
+          autopay: nested_closing.search("autopay").inner_text
         })
       end
 

--- a/spec/ofx/liability_closing_info_spec.rb
+++ b/spec/ofx/liability_closing_info_spec.rb
@@ -42,6 +42,7 @@ describe OFX::Parser::OFX102 do
         @credit_card_closing_info.past_due_amount.should == 615
         @credit_card_closing_info.last_payment_date.should == Time.gm(2018, 2, 6)
         @credit_card_closing_info.last_payment_amount.should == 73
+        @credit_card_closing_info.autopay.should == 'N'
       end
     end
 
@@ -56,6 +57,7 @@ describe OFX::Parser::OFX102 do
         @credit_card_closing_info.fit_id.should == 'FITIDCCSTMT1399928831'
         @credit_card_closing_info.last_payment_date.should == nil
         @credit_card_closing_info.last_payment_amount.should == nil
+        @credit_card_closing_info.autopay.should == 'N'
       end
     end
   end


### PR DESCRIPTION
@ouranos 

This is ofx changes for MARLINSUP-482 to support AUTOPAY flag. We may also need to support AUTOPAYAMT but we don't have the response files from the customer yet.

I raised this pull request again staging-v2, because this is where the other changes needed are there.